### PR TITLE
demos: update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ listener = eventEmitter.addListener(eventName, (event: any) => {
 listener.stop();
 ```
 
+## Demos
+
+To highlight the functionality of `lnc-rn` we've included two demos in the repo: `connect-demo` and `multi-connect-demo`. To run these you must run `npm run install-lnc` after installing their npm dependencies to fetch the LNC mobile binaries, which are not bundled into the module directly.
+
 ## Further documentation
 
 - https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/lnc-npm

--- a/demos/connect-demo/ios/Podfile.lock
+++ b/demos/connect-demo/ios/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
   - glog (0.3.5)
   - hermes-engine (0.70.6)
   - libevent (2.1.12)
-  - lnc-rn (0.1.11-alpha.1):
+  - lnc-rn (0.2.1-alpha.2):
     - React
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 2af7b7a59128f250adfd86f15aa1d5a2ecd39995
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  lnc-rn: 436823281176c6c5818dd249629a32318d3537d0
+  lnc-rn: 4c1d7510e5b36069a993697a08468c0d2cedcdae
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: e1866f61af7049eb3d8e08e8b133abd38bc1ca7a

--- a/demos/connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
+++ b/demos/connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		74D902A22930F65800BC2EBB /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74D902A12930F65800BC2EBB /* Lncmobile.xcframework */; };
+		7436416C294A297A002AB00B /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7436416B294A297A002AB00B /* Lncmobile.xcframework */; };
 		7699B88040F8A987B510C191 /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-lncmobiledemo-lncmobiledemoTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -42,7 +42,7 @@
 		5709B34CF0A7D63546082F79 /* Pods-lncmobiledemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-lncmobiledemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		74D902A12930F65800BC2EBB /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = ../../../ios/Lncmobile.xcframework; sourceTree = "<group>"; };
+		7436416B294A297A002AB00B /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = "../node_modules/@lightninglabs/lnc-rn/ios/Lncmobile.xcframework"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = lncmobiledemo/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -62,7 +62,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C80B921A6F3F58F76C31292 /* libPods-lncmobiledemo.a in Frameworks */,
-				74D902A22930F65800BC2EBB /* Lncmobile.xcframework in Frameworks */,
+				7436416C294A297A002AB00B /* Lncmobile.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,7 +102,7 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				74D902A12930F65800BC2EBB /* Lncmobile.xcframework */,
+				7436416B294A297A002AB00B /* Lncmobile.xcframework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				5DCACB8F33CDC322A6C60F78 /* libPods-lncmobiledemo.a */,
 				19F6CBCC0A4E27FBF8BF4A61 /* libPods-lncmobiledemo-lncmobiledemoTests.a */,

--- a/demos/connect-demo/metro.config.js
+++ b/demos/connect-demo/metro.config.js
@@ -6,9 +6,6 @@ module.exports = (async () => {
     resolver: { sourceExts, assetExts }
   } = await getDefaultConfig();
   return {
-    watchFolders: [
-      path.resolve(path.join('..','..')),
-    ],
     resolver: {
       assetExts: assetExts.filter(ext => ext !== 'svg'),
       sourceExts: [...sourceExts, 'svg']

--- a/demos/connect-demo/package-lock.json
+++ b/demos/connect-demo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "connect-demo",
       "version": "0.0.1",
       "dependencies": {
-        "@lightninglabs/lnc-rn": "file:///Users/satoshi/Repos/lightninglabs/lnc-rn",
+        "@lightninglabs/lnc-rn": "0.2.1-alpha.2",
         "@react-native-community/masked-view": "0.1.11",
         "@react-navigation/native": "6.0.13",
         "mobx": "6.6.2",
@@ -40,69 +40,6 @@
         "metro-react-native-babel-preset": "0.72.3",
         "prettier": "2.7.1",
         "typescript": "4.8.3"
-      }
-    },
-    "../..": {
-      "name": "@lightninglabs/lnc-rn",
-      "version": "0.1.11-alpha.1",
-      "license": "MIT",
-      "dependencies": {
-        "@lightninglabs/lnc-core": "v0.1.12-alpha"
-      },
-      "devDependencies": {
-        "@babel/core": "7.18.10",
-        "@babel/runtime": "7.18.9",
-        "@types/debug": "4.1.7",
-        "@types/node": "17.0.16",
-        "@types/react-native": "0.70.2",
-        "chai": "4.3.6",
-        "metro-react-native-babel-preset": "0.72.0",
-        "mocha": "9.2.2",
-        "prettier": "2.6.0",
-        "react-native": "0.68.2",
-        "react-native-builder-bob": "0.18.3",
-        "ts-loader": "9.2.6",
-        "ts-node": "10.7.0",
-        "ts-proto": "1.115.4",
-        "tslint": "6.1.3",
-        "tslint-config-prettier": "1.18.0",
-        "typescript": "4.5.5"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "../../Repos/lightninglabs/lnc-rn": {
-      "name": "@lightninglabs/lnc-rn",
-      "version": "0.1.11-alpha.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lightninglabs/lnc-core": "v0.1.12-alpha"
-      },
-      "devDependencies": {
-        "@babel/core": "7.18.10",
-        "@babel/runtime": "7.18.9",
-        "@types/debug": "4.1.7",
-        "@types/node": "17.0.16",
-        "@types/react-native": "0.70.2",
-        "chai": "4.3.6",
-        "metro-react-native-babel-preset": "0.72.0",
-        "mocha": "9.2.2",
-        "prettier": "2.6.0",
-        "react-native": "0.68.2",
-        "react-native-builder-bob": "0.18.3",
-        "ts-loader": "9.2.6",
-        "ts-node": "10.7.0",
-        "ts-proto": "1.115.4",
-        "tslint": "6.1.3",
-        "tslint-config-prettier": "1.18.0",
-        "typescript": "4.5.5"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2298,9 +2235,22 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@lightninglabs/lnc-core": {
+      "version": "0.2.1-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.2.1-alpha.tgz",
+      "integrity": "sha512-H297V3seL+PE786HcuAQiSass/3y0NSYCy3b4hNTZL4Io80Oy4WY49s08CpRuV8cNfjAzWjYSXkhorALjaRdwA=="
+    },
     "node_modules/@lightninglabs/lnc-rn": {
-      "resolved": "../..",
-      "link": true
+      "version": "0.2.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-rn/-/lnc-rn-0.2.1-alpha.2.tgz",
+      "integrity": "sha512-yLn80pmWlPGNcFH8Ha2k9bBxRjMrGGk7ZUaQ2QtAAmnn/+SXavtm4h03NLJHKPkID0I9+hfqEgV+Dg+NpaR6vA==",
+      "dependencies": {
+        "@lightninglabs/lnc-core": "0.2.1-alpha"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -12167,27 +12117,17 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@lightninglabs/lnc-core": {
+      "version": "0.2.1-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.2.1-alpha.tgz",
+      "integrity": "sha512-H297V3seL+PE786HcuAQiSass/3y0NSYCy3b4hNTZL4Io80Oy4WY49s08CpRuV8cNfjAzWjYSXkhorALjaRdwA=="
+    },
     "@lightninglabs/lnc-rn": {
-      "version": "file:../..",
+      "version": "0.2.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-rn/-/lnc-rn-0.2.1-alpha.2.tgz",
+      "integrity": "sha512-yLn80pmWlPGNcFH8Ha2k9bBxRjMrGGk7ZUaQ2QtAAmnn/+SXavtm4h03NLJHKPkID0I9+hfqEgV+Dg+NpaR6vA==",
       "requires": {
-        "@babel/core": "7.18.10",
-        "@babel/runtime": "7.18.9",
-        "@lightninglabs/lnc-core": "v0.1.12-alpha",
-        "@types/debug": "4.1.7",
-        "@types/node": "17.0.16",
-        "@types/react-native": "0.70.2",
-        "chai": "4.3.6",
-        "metro-react-native-babel-preset": "0.72.0",
-        "mocha": "9.2.2",
-        "prettier": "2.6.0",
-        "react-native": "0.68.2",
-        "react-native-builder-bob": "0.18.3",
-        "ts-loader": "9.2.6",
-        "ts-node": "10.7.0",
-        "ts-proto": "1.115.4",
-        "tslint": "6.1.3",
-        "tslint-config-prettier": "1.18.0",
-        "typescript": "4.5.5"
+        "@lightninglabs/lnc-core": "0.2.1-alpha"
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/demos/connect-demo/package.json
+++ b/demos/connect-demo/package.json
@@ -10,7 +10,7 @@
     "prettier-write": "prettier --check --write '**/*.ts*'"
   },
   "dependencies": {
-    "@lightninglabs/lnc-rn": "file:///Users/satoshi/Repos/lightninglabs/lnc-rn",
+    "@lightninglabs/lnc-rn": "0.2.1-alpha.2",
     "@react-native-community/masked-view": "0.1.11",
     "@react-navigation/native": "6.0.13",
     "mobx": "6.6.2",

--- a/demos/connect-demo/package.json
+++ b/demos/connect-demo/package.json
@@ -7,7 +7,8 @@
     "tsc": "tsc",
     "lint": "eslint --ext .js,.ts,.tsx '*.@(js|ts|tsx)' .",
     "prettier": "prettier --check '**/*.ts*'",
-    "prettier-write": "prettier --check --write '**/*.ts*'"
+    "prettier-write": "prettier --check --write '**/*.ts*'",
+    "install-lnc": "cd node_modules/@lightninglabs/lnc-rn; yarn run fetch-libraries"
   },
   "dependencies": {
     "@lightninglabs/lnc-rn": "0.2.1-alpha.2",

--- a/demos/multi-connect-demo/ios/Podfile.lock
+++ b/demos/multi-connect-demo/ios/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
   - glog (0.3.5)
   - hermes-engine (0.70.6)
   - libevent (2.1.12)
-  - lnc-rn (0.1.11-alpha.1):
+  - lnc-rn (0.2.1-alpha.2):
     - React
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 2af7b7a59128f250adfd86f15aa1d5a2ecd39995
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  lnc-rn: 436823281176c6c5818dd249629a32318d3537d0
+  lnc-rn: 4c1d7510e5b36069a993697a08468c0d2cedcdae
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: e1866f61af7049eb3d8e08e8b133abd38bc1ca7a

--- a/demos/multi-connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
+++ b/demos/multi-connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		74D902A42930F72500BC2EBB /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74D902A32930F72500BC2EBB /* Lncmobile.xcframework */; };
+		74A129D6294A2A5C00C7A86C /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74A129D5294A2A5B00C7A86C /* Lncmobile.xcframework */; };
 		7699B88040F8A987B510C191 /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-lncmobiledemo-lncmobiledemoTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -42,7 +42,7 @@
 		5709B34CF0A7D63546082F79 /* Pods-lncmobiledemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-lncmobiledemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		74D902A32930F72500BC2EBB /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = ../../../ios/Lncmobile.xcframework; sourceTree = "<group>"; };
+		74A129D5294A2A5B00C7A86C /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = "../node_modules/@lightninglabs/lnc-rn/ios/Lncmobile.xcframework"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = lncmobiledemo/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -62,7 +62,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C80B921A6F3F58F76C31292 /* libPods-lncmobiledemo.a in Frameworks */,
-				74D902A42930F72500BC2EBB /* Lncmobile.xcframework in Frameworks */,
+				74A129D6294A2A5C00C7A86C /* Lncmobile.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,7 +102,7 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				74D902A32930F72500BC2EBB /* Lncmobile.xcframework */,
+				74A129D5294A2A5B00C7A86C /* Lncmobile.xcframework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				5DCACB8F33CDC322A6C60F78 /* libPods-lncmobiledemo.a */,
 				19F6CBCC0A4E27FBF8BF4A61 /* libPods-lncmobiledemo-lncmobiledemoTests.a */,

--- a/demos/multi-connect-demo/metro.config.js
+++ b/demos/multi-connect-demo/metro.config.js
@@ -6,9 +6,6 @@ module.exports = (async () => {
     resolver: { sourceExts, assetExts }
   } = await getDefaultConfig();
   return {
-    watchFolders: [
-      path.resolve(path.join('..','..')),
-    ],
     resolver: {
       assetExts: assetExts.filter(ext => ext !== 'svg'),
       sourceExts: [...sourceExts, 'svg']

--- a/demos/multi-connect-demo/package-lock.json
+++ b/demos/multi-connect-demo/package-lock.json
@@ -8,7 +8,7 @@
       "name": "multi-connect-demo",
       "version": "0.0.1",
       "dependencies": {
-        "@lightninglabs/lnc-rn": "file:///Users/satoshi/Repos/lightninglabs/lnc-rn",
+        "@lightninglabs/lnc-rn": "0.2.1-alpha.2",
         "@react-native-community/masked-view": "0.1.11",
         "@react-navigation/native": "6.0.13",
         "mobx": "6.6.2",
@@ -40,68 +40,6 @@
         "metro-react-native-babel-preset": "0.72.3",
         "prettier": "2.7.1",
         "typescript": "4.8.3"
-      }
-    },
-    "../..": {
-      "version": "0.1.11-alpha.1",
-      "license": "MIT",
-      "dependencies": {
-        "@lightninglabs/lnc-core": "v0.1.12-alpha"
-      },
-      "devDependencies": {
-        "@babel/core": "7.18.10",
-        "@babel/runtime": "7.18.9",
-        "@types/debug": "4.1.7",
-        "@types/node": "17.0.16",
-        "@types/react-native": "0.70.2",
-        "chai": "4.3.6",
-        "metro-react-native-babel-preset": "0.72.0",
-        "mocha": "9.2.2",
-        "prettier": "2.6.0",
-        "react-native": "0.68.2",
-        "react-native-builder-bob": "0.18.3",
-        "ts-loader": "9.2.6",
-        "ts-node": "10.7.0",
-        "ts-proto": "1.115.4",
-        "tslint": "6.1.3",
-        "tslint-config-prettier": "1.18.0",
-        "typescript": "4.5.5"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "../../Repos/lightninglabs/lnc-rn": {
-      "name": "@lightninglabs/lnc-rn",
-      "version": "0.1.11-alpha.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lightninglabs/lnc-core": "v0.1.12-alpha"
-      },
-      "devDependencies": {
-        "@babel/core": "7.18.10",
-        "@babel/runtime": "7.18.9",
-        "@types/debug": "4.1.7",
-        "@types/node": "17.0.16",
-        "@types/react-native": "0.70.2",
-        "chai": "4.3.6",
-        "metro-react-native-babel-preset": "0.72.0",
-        "mocha": "9.2.2",
-        "prettier": "2.6.0",
-        "react-native": "0.68.2",
-        "react-native-builder-bob": "0.18.3",
-        "ts-loader": "9.2.6",
-        "ts-node": "10.7.0",
-        "ts-proto": "1.115.4",
-        "tslint": "6.1.3",
-        "tslint-config-prettier": "1.18.0",
-        "typescript": "4.5.5"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2297,9 +2235,22 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@lightninglabs/lnc-core": {
+      "version": "0.2.1-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.2.1-alpha.tgz",
+      "integrity": "sha512-H297V3seL+PE786HcuAQiSass/3y0NSYCy3b4hNTZL4Io80Oy4WY49s08CpRuV8cNfjAzWjYSXkhorALjaRdwA=="
+    },
     "node_modules/@lightninglabs/lnc-rn": {
-      "resolved": "../..",
-      "link": true
+      "version": "0.2.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-rn/-/lnc-rn-0.2.1-alpha.2.tgz",
+      "integrity": "sha512-yLn80pmWlPGNcFH8Ha2k9bBxRjMrGGk7ZUaQ2QtAAmnn/+SXavtm4h03NLJHKPkID0I9+hfqEgV+Dg+NpaR6vA==",
+      "dependencies": {
+        "@lightninglabs/lnc-core": "0.2.1-alpha"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -12166,27 +12117,17 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@lightninglabs/lnc-core": {
+      "version": "0.2.1-alpha",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-core/-/lnc-core-0.2.1-alpha.tgz",
+      "integrity": "sha512-H297V3seL+PE786HcuAQiSass/3y0NSYCy3b4hNTZL4Io80Oy4WY49s08CpRuV8cNfjAzWjYSXkhorALjaRdwA=="
+    },
     "@lightninglabs/lnc-rn": {
-      "version": "file:../..",
+      "version": "0.2.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/@lightninglabs/lnc-rn/-/lnc-rn-0.2.1-alpha.2.tgz",
+      "integrity": "sha512-yLn80pmWlPGNcFH8Ha2k9bBxRjMrGGk7ZUaQ2QtAAmnn/+SXavtm4h03NLJHKPkID0I9+hfqEgV+Dg+NpaR6vA==",
       "requires": {
-        "@babel/core": "7.18.10",
-        "@babel/runtime": "7.18.9",
-        "@lightninglabs/lnc-core": "v0.1.12-alpha",
-        "@types/debug": "4.1.7",
-        "@types/node": "17.0.16",
-        "@types/react-native": "0.70.2",
-        "chai": "4.3.6",
-        "metro-react-native-babel-preset": "0.72.0",
-        "mocha": "9.2.2",
-        "prettier": "2.6.0",
-        "react-native": "0.68.2",
-        "react-native-builder-bob": "0.18.3",
-        "ts-loader": "9.2.6",
-        "ts-node": "10.7.0",
-        "ts-proto": "1.115.4",
-        "tslint": "6.1.3",
-        "tslint-config-prettier": "1.18.0",
-        "typescript": "4.5.5"
+        "@lightninglabs/lnc-core": "0.2.1-alpha"
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/demos/multi-connect-demo/package.json
+++ b/demos/multi-connect-demo/package.json
@@ -9,7 +9,7 @@
     "prettier-write": "prettier --check --write '**/*.ts*'"
   },
   "dependencies": {
-    "@lightninglabs/lnc-rn": "file:///Users/satoshi/Repos/lightninglabs/lnc-rn",
+    "@lightninglabs/lnc-rn": "0.2.1-alpha.2",
     "@react-native-community/masked-view": "0.1.11",
     "@react-navigation/native": "6.0.13",
     "mobx": "6.6.2",

--- a/demos/multi-connect-demo/package.json
+++ b/demos/multi-connect-demo/package.json
@@ -6,7 +6,8 @@
     "tsc": "tsc",
     "lint": "eslint --ext .js,.ts,.tsx '*.@(js|ts|tsx)' .",
     "prettier": "prettier --check '**/*.ts*'",
-    "prettier-write": "prettier --check --write '**/*.ts*'"
+    "prettier-write": "prettier --check --write '**/*.ts*'",
+    "install-lnc": "cd node_modules/@lightninglabs/lnc-rn; yarn run fetch-libraries"
   },
   "dependencies": {
     "@lightninglabs/lnc-rn": "0.2.1-alpha.2",

--- a/demos/multi-connect-demo/stores/LNCStore.ts
+++ b/demos/multi-connect-demo/stores/LNCStore.ts
@@ -43,10 +43,24 @@ export default class LNCStore {
         await this.lnc1.connect();
         await this.lnc2.connect();
 
-        this.loading = false;
-        this.connected = true;
-
-        return;
+        return new Promise<void>((resolve) => {
+            let counter = 0;
+            const interval = setInterval(async () => {
+                counter++;
+                const connected1 = await this.lnc1.isConnected();
+                const connected2 = await this.lnc2.isConnected();
+                if (connected1 && connected2) {
+                    clearInterval(interval);
+                    this.loading = false;
+                    this.connected = true;
+                    resolve();
+                } else if (counter > 20) {
+                    clearInterval(interval);
+                    this.loading = false;
+                    resolve();
+                }
+            }, 500);
+        });
     };
 
     @action


### PR DESCRIPTION
This PR updates the demos to leverage`lnc-rn` from npm, rather than from the project root. 

TODO
- [x] update Podfiles
- [x] update iOS project configs
- [x] add `install-lnc` command to npm scripts
- [x] add install instructions for demos to `README`