### PR TITLE
scripts: fetch-libraries: run with bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "preversion": "npm run lint",
     "version": "npm run prettier && git add -A lib",
     "postversion": "git push && git push --tags",
-    "fetch-libraries": "chmod +x fetch-libraries.sh; ./fetch-libraries.sh"
+    "fetch-libraries": "bash fetch-libraries.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
While running on Ubuntu I found that our checks to see if the `curl` and `unzip` commands were installed failed unless run with `bash`