### PR TITLE
v0.2.3-alpha

### DIFF
--- a/fetch-libraries.sh
+++ b/fetch-libraries.sh
@@ -1,4 +1,4 @@
-VERSION=v0.2.2-alpha
+VERSION=v0.2.3-alpha
 
 ANDROID_ZIP_NAME=lnc-$VERSION-android.zip
 IOS_ZIP_NAME=lnc-$VERSION-ios.zip

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -1,6 +1,7 @@
 import { NativeModules } from 'react-native';
 import {
     FaradayApi,
+    LitApi,
     LndApi,
     LoopApi,
     PoolApi,
@@ -25,6 +26,7 @@ export default class LNC {
     loop: LoopApi;
     pool: PoolApi;
     faraday: FaradayApi;
+    lit: LitApi;
 
     constructor(lncConfig?: LncConfig) {
         // merge the passed in config with the defaults
@@ -47,6 +49,7 @@ export default class LNC {
         this.loop = new LoopApi(createRpc, this);
         this.pool = new PoolApi(createRpc, this);
         this.faraday = new FaradayApi(createRpc, this);
+        this.lit = new LitApi(createRpc, this);
 
         NativeModules.LncModule.initLNC(this._namespace);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-rn",
-  "version": "0.2.2-alpha",
+  "version": "0.2.3-alpha",
   "description": "Lightning Node Connect npm module for React Native",
   "main": "dist/commonjs/index.js",
   "types": "dist/typescript/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/lightninglabs/lnc-rn#readme",
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.2.2-alpha"
+    "@lightninglabs/lnc-core": "0.2.3-alpha"
   },
   "devDependencies": {
     "@babel/core": "7.18.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,10 +1181,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.2.2-alpha":
-  version "0.2.2-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.2-alpha.tgz#37e1dcf3419844f70e5df7901ec55cb62a9b0b1e"
-  integrity sha512-S46tZ6cH7jPgrotbZS9Pceyb2Nf+gaC9gmorm1DC7OpWxaf2gilelNk+0wVf9B8pqIwnBfr1z3h/sTophvLkUQ==
+"@lightninglabs/lnc-core@0.2.3-alpha":
+  version "0.2.3-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.3-alpha.tgz#e1b92a9071d1dfb92e2d565710b56f28f57cbbd4"
+  integrity sha512-93D/uU64ayAaJv5kv4Pqwvkt+uT7yCtmHD08aUzvql+lbWm6U7m5loZLxz7tACFLXVPOQ8OHJL25W+3QMEYthg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
- Exposes new `LitApi`
- Bump `lnc-core` to `v0.2.3-alpha`
- Bump version for library fetch script
- Version bump to `v0.2.3-alpha`