### PR TITLE
Remove all references to WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ import LNC from ‘@lightninglabs/lnc-rn’;
 
 const pairingPhrase = ‘artefact morning piano photo consider light’;
 
-// default connection using WASM from CDN
-// WASM loaded on object creation
+// default connection
 // default host: mailbox.terminal.lightning.today:443
 const lnc = new LNC({
    pairingPhrase

--- a/lib/api/createRpc.ts
+++ b/lib/api/createRpc.ts
@@ -5,8 +5,8 @@ import { subscriptionMethods } from '@lightninglabs/lnc-core';
 const capitalize = (s: string) => s && s[0].toUpperCase() + s.slice(1);
 
 /**
- * Creates a typed Proxy object which calls the WASM request or
- * subscribe methods depending on which function is called on the object
+ * Creates a typed Proxy object which calls the request or subscribe
+ * methods depending on which function is called on the object
  */
 export function createRpc<T extends object>(packageName: string, lnc: LNC): T {
     const rpc = {};

--- a/lib/lnc.ts
+++ b/lib/lnc.ts
@@ -10,7 +10,7 @@ import {
 import { createRpc } from './api/createRpc';
 import { CredentialStore, LncConfig } from './types/lnc';
 import LncCredentialStore from './util/credentialStore';
-import { wasmLog as log } from './util/log';
+import { log } from './util/log';
 
 /** The default values for the LncConfig options */
 const DEFAULT_CONFIG = {
@@ -138,7 +138,7 @@ export default class LNC {
     }
 
     /**
-     * Emulates a GRPC request but uses the WASM client instead to communicate with the LND node
+     * Emulates a GRPC request but uses the mobile client instead to communicate with the LND node
      * @param method the GRPC method to call on the service
      * @param request The GRPC request message to send
      */

--- a/lib/util/log.ts
+++ b/lib/util/log.ts
@@ -85,11 +85,6 @@ export const log = Logger.fromEnv('main');
 export const grpcLog = Logger.fromEnv('grpc');
 
 /**
- * the logger for WASM requests and responses
- */
-export const wasmLog = Logger.fromEnv('wasm');
-
-/**
  * the logger for state updates via mobx actions
  */
 export const actionLog = Logger.fromEnv('action');


### PR DESCRIPTION
lnc-rn uses native binaries built from golang using gomobile, but we left some of the references in the repo to the wasm from lnc-web module.

This PR removes all unnecessary WASM references.