### PR TITLE
config: bump version to v0.2.5-alpha

### DIFF
--- a/fetch-libraries.sh
+++ b/fetch-libraries.sh
@@ -1,4 +1,4 @@
-VERSION=v0.2.4-alpha
+VERSION=v0.2.5-alpha
 
 ANDROID_ZIP_NAME=lnc-$VERSION-android.zip
 IOS_ZIP_NAME=lnc-$VERSION-ios.zip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightninglabs/lnc-rn",
-  "version": "0.2.4-alpha",
+  "version": "0.2.5-alpha",
   "description": "Lightning Node Connect npm module for React Native",
   "main": "dist/commonjs/index.js",
   "types": "dist/typescript/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/lightninglabs/lnc-rn#readme",
   "dependencies": {
-    "@lightninglabs/lnc-core": "0.2.4-alpha"
+    "@lightninglabs/lnc-core": "^0.2.5-alpha"
   },
   "devDependencies": {
     "@babel/core": "7.18.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,10 +1181,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@0.2.4-alpha":
-  version "0.2.4-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.4-alpha.tgz#3864ea91cd57d3340ed250cdff9318ba6dbcfe6e"
-  integrity sha512-vZQJzMB5tWW/GFxUFyxrfDAGM8Q4jz55vjO4IJyp9Pk8fxBeYEyYJYF8+cJ9/9CKZ7fgX9MPp8m08oOVjJVlhQ==
+"@lightninglabs/lnc-core@^0.2.5-alpha":
+  version "0.2.5-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.2.5-alpha.tgz#4150b9d8002a8dac582edc6216581feb2b613196"
+  integrity sha512-mdofMCydpNLAf0Abwy81FsuOMIrUqsxR5kZ9Qzjp+E7bZdMntsKY3p0oqq/y3o/6hfrKN7Ornht42Cebc/i9Iw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
Updates `lnc-core` dependency to v0.2.5-alpha and bumps `lnc-rn` version to v0.2.5-alpha.