### PR TITLE
Bump demo apps to use `lnc-rn` `v0.3.2-alpha`

### DIFF
--- a/demos/connect-demo/ios/Podfile.lock
+++ b/demos/connect-demo/ios/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
   - glog (0.3.5)
   - hermes-engine (0.70.6)
   - libevent (2.1.12)
-  - lnc-rn (0.3.1-alpha):
+  - lnc-rn (0.3.2-alpha):
     - React
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 2af7b7a59128f250adfd86f15aa1d5a2ecd39995
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  lnc-rn: 275c1a82b7bdd80fe0efd73fe04c2b1ee432499c
+  lnc-rn: 636ff81771aa96e9dc59c17f682671f738233b84
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: e1866f61af7049eb3d8e08e8b133abd38bc1ca7a

--- a/demos/connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
+++ b/demos/connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
@@ -11,10 +11,10 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		1E1BEEB611965E82BBD9F326 /* libPods-lncmobiledemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 687784A5D6940523ACA2792D /* libPods-lncmobiledemo.a */; };
-		6BFC03CF8A7D9A64BC5F1DF7 /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 811246B7844C36C021177C29 /* libPods-lncmobiledemo-lncmobiledemoTests.a */; };
+		204D43741BE68B25D3560A74 /* libPods-lncmobiledemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 37D9F77644C27F18F22A5BEE /* libPods-lncmobiledemo.a */; };
+		28C1600C950908ECCF4EE98D /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A7658C5D7B21D4642D05293C /* libPods-lncmobiledemo-lncmobiledemoTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		C86E78D22C582F9B0025B77D /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C86E78D12C582F9B0025B77D /* Lncmobile.xcframework */; };
+		C871BC372C5945C30075FA7B /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C871BC362C5945C30075FA7B /* Lncmobile.xcframework */; };
 		C8A5A7742B7CD641001C4BBE /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A5A7732B7CD641001C4BBE /* libresolv.9.tbd */; };
 /* End PBXBuildFile section */
 
@@ -38,16 +38,16 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = lncmobiledemo/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = lncmobiledemo/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = lncmobiledemo/main.m; sourceTree = "<group>"; };
-		30E750BDE5F239EFCD135078 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		62443A84BE43B8BB47427051 /* Pods-lncmobiledemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.debug.xcconfig"; sourceTree = "<group>"; };
-		687784A5D6940523ACA2792D /* libPods-lncmobiledemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		811246B7844C36C021177C29 /* libPods-lncmobiledemo-lncmobiledemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo-lncmobiledemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E169A200D3B5220B1DE1BD1 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		37D9F77644C27F18F22A5BEE /* libPods-lncmobiledemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		75E135B658BCB0505ED80AAB /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = lncmobiledemo/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		C86E78D12C582F9B0025B77D /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = "../node_modules/@lightninglabs/lnc-rn/ios/Lncmobile.xcframework"; sourceTree = "<group>"; };
+		8EB4EBEABB7ADE034399C59F /* Pods-lncmobiledemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.debug.xcconfig"; sourceTree = "<group>"; };
+		A7658C5D7B21D4642D05293C /* libPods-lncmobiledemo-lncmobiledemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo-lncmobiledemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C871BC362C5945C30075FA7B /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = "../node_modules/@lightninglabs/lnc-rn/ios/Lncmobile.xcframework"; sourceTree = "<group>"; };
 		C8A5A7732B7CD641001C4BBE /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = usr/lib/libresolv.9.tbd; sourceTree = SDKROOT; };
-		E7C56295FA93AEBB59A119A9 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		D333BDDEF69C2961E346AEFC /* Pods-lncmobiledemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		F5377606169A0E0F845F70B9 /* Pods-lncmobiledemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6BFC03CF8A7D9A64BC5F1DF7 /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */,
+				28C1600C950908ECCF4EE98D /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,8 +64,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C8A5A7742B7CD641001C4BBE /* libresolv.9.tbd in Frameworks */,
-				C86E78D22C582F9B0025B77D /* Lncmobile.xcframework in Frameworks */,
-				1E1BEEB611965E82BBD9F326 /* libPods-lncmobiledemo.a in Frameworks */,
+				C871BC372C5945C30075FA7B /* Lncmobile.xcframework in Frameworks */,
+				204D43741BE68B25D3560A74 /* libPods-lncmobiledemo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,11 +105,11 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C86E78D12C582F9B0025B77D /* Lncmobile.xcframework */,
+				C871BC362C5945C30075FA7B /* Lncmobile.xcframework */,
 				C8A5A7732B7CD641001C4BBE /* libresolv.9.tbd */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				687784A5D6940523ACA2792D /* libPods-lncmobiledemo.a */,
-				811246B7844C36C021177C29 /* libPods-lncmobiledemo-lncmobiledemoTests.a */,
+				37D9F77644C27F18F22A5BEE /* libPods-lncmobiledemo.a */,
+				A7658C5D7B21D4642D05293C /* libPods-lncmobiledemo-lncmobiledemoTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -148,10 +148,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				62443A84BE43B8BB47427051 /* Pods-lncmobiledemo.debug.xcconfig */,
-				F5377606169A0E0F845F70B9 /* Pods-lncmobiledemo.release.xcconfig */,
-				30E750BDE5F239EFCD135078 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */,
-				E7C56295FA93AEBB59A119A9 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */,
+				8EB4EBEABB7ADE034399C59F /* Pods-lncmobiledemo.debug.xcconfig */,
+				D333BDDEF69C2961E346AEFC /* Pods-lncmobiledemo.release.xcconfig */,
+				1E169A200D3B5220B1DE1BD1 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */,
+				75E135B658BCB0505ED80AAB /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -163,12 +163,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "lncmobiledemoTests" */;
 			buildPhases = (
-				5F032D47441FC779C34CE1CA /* [CP] Check Pods Manifest.lock */,
+				193DFB0BBC6EE30CF1602513 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				C5DE79256D37FCEDD3B4B50E /* [CP] Embed Pods Frameworks */,
-				2422B544E74BD3BDA01144ED /* [CP] Copy Pods Resources */,
+				5D2685A9778E6256AB916E43 /* [CP] Embed Pods Frameworks */,
+				0F3412B3AB7F26CE98BA404E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -184,14 +184,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "lncmobiledemo" */;
 			buildPhases = (
-				920ACA39A67CDB657CF250EF /* [CP] Check Pods Manifest.lock */,
+				4DD25EA8D2564C11FB341725 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				687F24AEA794D995490483AE /* [CP] Embed Pods Frameworks */,
-				53EEB2178B3503015AF2B496 /* [CP] Copy Pods Resources */,
+				24B3FAF3EE8C2085012BC848 /* [CP] Embed Pods Frameworks */,
+				17FE8418FF898A48B8A0CC5A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -274,7 +274,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		2422B544E74BD3BDA01144ED /* [CP] Copy Pods Resources */ = {
+		0F3412B3AB7F26CE98BA404E /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -291,7 +291,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		53EEB2178B3503015AF2B496 /* [CP] Copy Pods Resources */ = {
+		17FE8418FF898A48B8A0CC5A /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -308,7 +308,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5F032D47441FC779C34CE1CA /* [CP] Check Pods Manifest.lock */ = {
+		193DFB0BBC6EE30CF1602513 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -330,7 +330,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		687F24AEA794D995490483AE /* [CP] Embed Pods Frameworks */ = {
+		24B3FAF3EE8C2085012BC848 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -347,7 +347,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		920ACA39A67CDB657CF250EF /* [CP] Check Pods Manifest.lock */ = {
+		4DD25EA8D2564C11FB341725 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -369,7 +369,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C5DE79256D37FCEDD3B4B50E /* [CP] Embed Pods Frameworks */ = {
+		5D2685A9778E6256AB916E43 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -438,7 +438,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 30E750BDE5F239EFCD135078 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */;
+			baseConfigurationReference = 1E169A200D3B5220B1DE1BD1 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -465,7 +465,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E7C56295FA93AEBB59A119A9 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */;
+			baseConfigurationReference = 75E135B658BCB0505ED80AAB /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -489,7 +489,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 62443A84BE43B8BB47427051 /* Pods-lncmobiledemo.debug.xcconfig */;
+			baseConfigurationReference = 8EB4EBEABB7ADE034399C59F /* Pods-lncmobiledemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -515,7 +515,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F5377606169A0E0F845F70B9 /* Pods-lncmobiledemo.release.xcconfig */;
+			baseConfigurationReference = D333BDDEF69C2961E346AEFC /* Pods-lncmobiledemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/demos/connect-demo/package.json
+++ b/demos/connect-demo/package.json
@@ -11,7 +11,7 @@
     "install-lnc": "cd node_modules/@lightninglabs/lnc-rn; yarn run fetch-libraries"
   },
   "dependencies": {
-    "@lightninglabs/lnc-rn": "0.3.1-alpha",
+    "@lightninglabs/lnc-rn": "0.3.2-alpha",
     "@react-native-community/masked-view": "0.1.11",
     "@react-navigation/native": "6.0.13",
     "mobx": "6.6.2",

--- a/demos/connect-demo/yarn.lock
+++ b/demos/connect-demo/yarn.lock
@@ -899,17 +899,17 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@^0.3.1-alpha":
-  version "0.3.1-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.1-alpha.tgz#cfd6c0857a20013fb1819b40bd1158a2edc8bcf0"
-  integrity sha512-I/hThdItLWJ6RU8Z27ZIXhpBS2JJuD3+TjtaQXX2CabaUYXlcN4sk+Kx8N/zG/fk8qZvjlRWum4vHu4ZX554Fg==
+"@lightninglabs/lnc-core@^0.3.2-alpha":
+  version "0.3.2-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.2-alpha.tgz#bde028a858a77d78af4885df8bd95b036103b736"
+  integrity sha512-H6tG+X9txCIdxTR+GPsbImzP2Juo+6Uvq/Ipaijd7xPISzgEU4J4GNE5PEHuIZqbnBo1RmpuXnFG6dmsl3PTzQ==
 
-"@lightninglabs/lnc-rn@0.3.1-alpha":
-  version "0.3.1-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-rn/-/lnc-rn-0.3.1-alpha.tgz#5d3e0e21bb3da5a63a7d1cee91aba60f9f3bd21f"
-  integrity sha512-3TVeqnaojGNkTr3WGLYD7DYnPvll4Yaj5nCAfDxlzy3TwPA2dRgYJS+lYfv1cWDf/sjCixd0aKVOKZ7HjUp6RQ==
+"@lightninglabs/lnc-rn@0.3.2-alpha":
+  version "0.3.2-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-rn/-/lnc-rn-0.3.2-alpha.tgz#eadd6cda92044a91b999a65d63337a6930811653"
+  integrity sha512-juCaIhwWrpiwmaXQp4JfZ7lULt8y9yaGDpWcHsaFjUHODdmFYWv6h5Ep+kgZkSlzmzQ6ajpJaEsCnMKiUOMYag==
   dependencies:
-    "@lightninglabs/lnc-core" "^0.3.1-alpha"
+    "@lightninglabs/lnc-core" "^0.3.2-alpha"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"

--- a/demos/multi-connect-demo/ios/Podfile.lock
+++ b/demos/multi-connect-demo/ios/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
   - glog (0.3.5)
   - hermes-engine (0.70.6)
   - libevent (2.1.12)
-  - lnc-rn (0.3.1-alpha):
+  - lnc-rn (0.3.2-alpha):
     - React
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 2af7b7a59128f250adfd86f15aa1d5a2ecd39995
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  lnc-rn: 275c1a82b7bdd80fe0efd73fe04c2b1ee432499c
+  lnc-rn: 636ff81771aa96e9dc59c17f682671f738233b84
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: e1866f61af7049eb3d8e08e8b133abd38bc1ca7a

--- a/demos/multi-connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
+++ b/demos/multi-connect-demo/ios/lncmobiledemo.xcodeproj/project.pbxproj
@@ -11,11 +11,11 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		64513C49235C46C423261218 /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B885D8556AEEF6B79C2FC591 /* libPods-lncmobiledemo-lncmobiledemoTests.a */; };
+		51835E988158B2ADCC8E495B /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B550943376CC31713BF94F67 /* libPods-lncmobiledemo-lncmobiledemoTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		BA5FA1676869F894FE561ED8 /* libPods-lncmobiledemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FDB4898D8659A35D6CED03F /* libPods-lncmobiledemo.a */; };
-		C86E78D42C5837980025B77D /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C86E78D32C5837980025B77D /* Lncmobile.xcframework */; };
+		C871BC392C5949D90075FA7B /* Lncmobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C871BC382C5949D90075FA7B /* Lncmobile.xcframework */; };
 		C8FFB7E42B83E55B00A6FE5F /* libresolv.9.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C8FFB7E32B83E55B00A6FE5F /* libresolv.9.tbd */; };
+		D349DD7E54341418E0EB02CC /* libPods-lncmobiledemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DAE2725829CAB6FCD4B6E894 /* libPods-lncmobiledemo.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,16 +38,16 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = lncmobiledemo/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = lncmobiledemo/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = lncmobiledemo/main.m; sourceTree = "<group>"; };
-		2F574C8B858EA0AD4D7DFCBF /* Pods-lncmobiledemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.release.xcconfig"; sourceTree = "<group>"; };
-		3ED389617228F1F00701DDEE /* Pods-lncmobiledemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.debug.xcconfig"; sourceTree = "<group>"; };
-		496B2F00275C248BFDBE24E8 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		6CCB1ED25487E7AFB10734A8 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		4A83F4E5FA085AEAC8F624E8 /* Pods-lncmobiledemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.release.xcconfig"; sourceTree = "<group>"; };
+		4AB28F9B4AE86BEB7CDB5CF0 /* Pods-lncmobiledemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = lncmobiledemo/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		9FDB4898D8659A35D6CED03F /* libPods-lncmobiledemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		B885D8556AEEF6B79C2FC591 /* libPods-lncmobiledemo-lncmobiledemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo-lncmobiledemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C86E78D32C5837980025B77D /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = "../node_modules/@lightninglabs/lnc-rn/ios/Lncmobile.xcframework"; sourceTree = "<group>"; };
+		B550943376CC31713BF94F67 /* libPods-lncmobiledemo-lncmobiledemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo-lncmobiledemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C84354238D09E28892AE7E21 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		C871BC382C5949D90075FA7B /* Lncmobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Lncmobile.xcframework; path = "../node_modules/@lightninglabs/lnc-rn/ios/Lncmobile.xcframework"; sourceTree = "<group>"; };
 		C8FFB7E32B83E55B00A6FE5F /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = usr/lib/libresolv.9.tbd; sourceTree = SDKROOT; };
+		DAE2725829CAB6FCD4B6E894 /* libPods-lncmobiledemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-lncmobiledemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F6731B81B569281EC4FD005A /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; path = "Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				64513C49235C46C423261218 /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */,
+				51835E988158B2ADCC8E495B /* libPods-lncmobiledemo-lncmobiledemoTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,8 +64,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C8FFB7E42B83E55B00A6FE5F /* libresolv.9.tbd in Frameworks */,
-				C86E78D42C5837980025B77D /* Lncmobile.xcframework in Frameworks */,
-				BA5FA1676869F894FE561ED8 /* libPods-lncmobiledemo.a in Frameworks */,
+				C871BC392C5949D90075FA7B /* Lncmobile.xcframework in Frameworks */,
+				D349DD7E54341418E0EB02CC /* libPods-lncmobiledemo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,11 +105,11 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C86E78D32C5837980025B77D /* Lncmobile.xcframework */,
+				C871BC382C5949D90075FA7B /* Lncmobile.xcframework */,
 				C8FFB7E32B83E55B00A6FE5F /* libresolv.9.tbd */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				9FDB4898D8659A35D6CED03F /* libPods-lncmobiledemo.a */,
-				B885D8556AEEF6B79C2FC591 /* libPods-lncmobiledemo-lncmobiledemoTests.a */,
+				DAE2725829CAB6FCD4B6E894 /* libPods-lncmobiledemo.a */,
+				B550943376CC31713BF94F67 /* libPods-lncmobiledemo-lncmobiledemoTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -148,10 +148,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3ED389617228F1F00701DDEE /* Pods-lncmobiledemo.debug.xcconfig */,
-				2F574C8B858EA0AD4D7DFCBF /* Pods-lncmobiledemo.release.xcconfig */,
-				496B2F00275C248BFDBE24E8 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */,
-				6CCB1ED25487E7AFB10734A8 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */,
+				4AB28F9B4AE86BEB7CDB5CF0 /* Pods-lncmobiledemo.debug.xcconfig */,
+				4A83F4E5FA085AEAC8F624E8 /* Pods-lncmobiledemo.release.xcconfig */,
+				F6731B81B569281EC4FD005A /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */,
+				C84354238D09E28892AE7E21 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -163,12 +163,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "lncmobiledemoTests" */;
 			buildPhases = (
-				EB845069EEB4CA8900FB9FD3 /* [CP] Check Pods Manifest.lock */,
+				49889246E4D91801872FE85B /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				B901573290B9AE96197A130A /* [CP] Embed Pods Frameworks */,
-				9CC2A0742A5451294940CEF1 /* [CP] Copy Pods Resources */,
+				20977FF5A189C1CC8DAAE116 /* [CP] Embed Pods Frameworks */,
+				098D32D7F92D8BF2B86E36D4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -184,14 +184,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "lncmobiledemo" */;
 			buildPhases = (
-				D943C24DA988CE6140964120 /* [CP] Check Pods Manifest.lock */,
+				357C202C249448E86DBAFFBF /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				1855CEA3023B92843F5994D2 /* [CP] Embed Pods Frameworks */,
-				216558F1F77A065E54486304 /* [CP] Copy Pods Resources */,
+				7EAEC8A226C762014D1337ED /* [CP] Embed Pods Frameworks */,
+				F2949D99DD87AA7DB325E63F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -274,41 +274,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		1855CEA3023B92843F5994D2 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		216558F1F77A065E54486304 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9CC2A0742A5451294940CEF1 /* [CP] Copy Pods Resources */ = {
+		098D32D7F92D8BF2B86E36D4 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -325,7 +291,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B901573290B9AE96197A130A /* [CP] Embed Pods Frameworks */ = {
+		20977FF5A189C1CC8DAAE116 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -342,7 +308,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo-lncmobiledemoTests/Pods-lncmobiledemo-lncmobiledemoTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D943C24DA988CE6140964120 /* [CP] Check Pods Manifest.lock */ = {
+		357C202C249448E86DBAFFBF /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -364,7 +330,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EB845069EEB4CA8900FB9FD3 /* [CP] Check Pods Manifest.lock */ = {
+		49889246E4D91801872FE85B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -384,6 +350,40 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7EAEC8A226C762014D1337ED /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F2949D99DD87AA7DB325E63F /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-lncmobiledemo/Pods-lncmobiledemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -438,7 +438,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 496B2F00275C248BFDBE24E8 /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */;
+			baseConfigurationReference = F6731B81B569281EC4FD005A /* Pods-lncmobiledemo-lncmobiledemoTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -465,7 +465,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6CCB1ED25487E7AFB10734A8 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */;
+			baseConfigurationReference = C84354238D09E28892AE7E21 /* Pods-lncmobiledemo-lncmobiledemoTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -489,7 +489,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3ED389617228F1F00701DDEE /* Pods-lncmobiledemo.debug.xcconfig */;
+			baseConfigurationReference = 4AB28F9B4AE86BEB7CDB5CF0 /* Pods-lncmobiledemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -515,7 +515,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2F574C8B858EA0AD4D7DFCBF /* Pods-lncmobiledemo.release.xcconfig */;
+			baseConfigurationReference = 4A83F4E5FA085AEAC8F624E8 /* Pods-lncmobiledemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/demos/multi-connect-demo/package.json
+++ b/demos/multi-connect-demo/package.json
@@ -10,7 +10,7 @@
     "install-lnc": "cd node_modules/@lightninglabs/lnc-rn; yarn run fetch-libraries"
   },
   "dependencies": {
-    "@lightninglabs/lnc-rn": "0.3.1-alpha",
+    "@lightninglabs/lnc-rn": "0.3.2-alpha",
     "@react-native-community/masked-view": "0.1.11",
     "@react-navigation/native": "6.0.13",
     "mobx": "6.6.2",

--- a/demos/multi-connect-demo/yarn.lock
+++ b/demos/multi-connect-demo/yarn.lock
@@ -899,17 +899,17 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@lightninglabs/lnc-core@^0.3.1-alpha":
-  version "0.3.1-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.1-alpha.tgz#cfd6c0857a20013fb1819b40bd1158a2edc8bcf0"
-  integrity sha512-I/hThdItLWJ6RU8Z27ZIXhpBS2JJuD3+TjtaQXX2CabaUYXlcN4sk+Kx8N/zG/fk8qZvjlRWum4vHu4ZX554Fg==
+"@lightninglabs/lnc-core@^0.3.2-alpha":
+  version "0.3.2-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-core/-/lnc-core-0.3.2-alpha.tgz#bde028a858a77d78af4885df8bd95b036103b736"
+  integrity sha512-H6tG+X9txCIdxTR+GPsbImzP2Juo+6Uvq/Ipaijd7xPISzgEU4J4GNE5PEHuIZqbnBo1RmpuXnFG6dmsl3PTzQ==
 
-"@lightninglabs/lnc-rn@0.3.1-alpha":
-  version "0.3.1-alpha"
-  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-rn/-/lnc-rn-0.3.1-alpha.tgz#5d3e0e21bb3da5a63a7d1cee91aba60f9f3bd21f"
-  integrity sha512-3TVeqnaojGNkTr3WGLYD7DYnPvll4Yaj5nCAfDxlzy3TwPA2dRgYJS+lYfv1cWDf/sjCixd0aKVOKZ7HjUp6RQ==
+"@lightninglabs/lnc-rn@0.3.2-alpha":
+  version "0.3.2-alpha"
+  resolved "https://registry.yarnpkg.com/@lightninglabs/lnc-rn/-/lnc-rn-0.3.2-alpha.tgz#eadd6cda92044a91b999a65d63337a6930811653"
+  integrity sha512-juCaIhwWrpiwmaXQp4JfZ7lULt8y9yaGDpWcHsaFjUHODdmFYWv6h5Ep+kgZkSlzmzQ6ajpJaEsCnMKiUOMYag==
   dependencies:
-    "@lightninglabs/lnc-core" "^0.3.1-alpha"
+    "@lightninglabs/lnc-core" "^0.3.2-alpha"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"


### PR DESCRIPTION
Based on #42

This PR updates the demo apps to use a local version of `lnc-rn` `v0.3.2-alpha`.

This is done to enable testing of that `lnc-rn` version.

Once that version has been released, I'll update this PR to use the actual release, and not a local version of `lnc-rn`.
Therefore pushing this PR in draft mode for now.