### PR TITLE
ci: switch npm workflow to use Trusted Publishing

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,6 +2,11 @@ name: Publish Package to npmjs
 on:
   release:
     types: [created]
+
+permissions:
+  id-token: write  # Required for NPM Trusted Publishing
+  contents: read
+    
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,9 +15,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish


### PR DESCRIPTION
NPM has deprecated publishing packages using classic access tokens, which will cause future publishing of a new release to fail. 

This update switches our CI workflow to use [Trusted Publishing](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow) to push the new package version to the NPM registry. I have already made the necessary config changes on npmjs.org.